### PR TITLE
Big simplification of the code update/deploy logic

### DIFF
--- a/nubis/builder/provisioners.json
+++ b/nubis/builder/provisioners.json
@@ -1,15 +1,9 @@
 {
 "provisioners": [
   {
-    "type": "file",
-    "source": "./ssl_compat",
-    "destination": "/tmp/ssl_compat",
-    "order": "1"
-  },
-  {
     "type": "shell",
     "inline": [
-      "sudo /bin/bash /opt/admin-scripts/update-site.sh"
+      "sudo /opt/admin-scripts/update-site.sh"
     ],
     "order": "99"
   }

--- a/nubis/puppet/files/update-repo.sh
+++ b/nubis/puppet/files/update-repo.sh
@@ -1,28 +1,31 @@
 #!/bin/bash -l
 # Update the local copy of this site's git repository
-# Copy the contents to the web root.
 #
 
 SOURCE_REPO=https://github.com/mwobensmith/ssl_compat.git
-LOCAL_REV=$(/usr/bin/git rev-parse master)
-REMOTE_REV=$(/usr/bin/git rev-parse origin/master)
+REPO_DIR=/var/lib/ssl_compat
 
-cd /tmp
+mkdir -p $REPO_DIR
 
 # Clone the repository if the local repo is empty or non-existent
-if [ ! -d /tmp/ssl_compat/.git ]
+if [ ! -d $REPO_DIR/.git ]
 then
-  rm -rf /tmp/ssl_compat
-  /usr/bin/git clone $SOURCE_REPO
+  rm -rf $REPO_DIR
+  /usr/bin/git clone $SOURCE_REPO $REPO_DIR
 fi
 
 # Otherwise, let's just git pull when needed
-cd /tmp/ssl_compat
+cd $REPO_DIR
 /usr/bin/git remote update
+
+LOCAL_REV=$(/usr/bin/git rev-parse master)
+REMOTE_REV=$(/usr/bin/git rev-parse origin/master)
 
 # git pull if master and origin/master do not match
 # The local repository should never be ahead of origin/master
 if [ $LOCAL_REV != $REMOTE_REV ]
 then
   /usr/bin/git pull
+  /usr/bin/git describe --always --tags --dirty > _revision.info
 fi
+

--- a/nubis/puppet/files/update-repo.sh
+++ b/nubis/puppet/files/update-repo.sh
@@ -5,13 +5,20 @@
 SOURCE_REPO=https://github.com/mwobensmith/ssl_compat.git
 REPO_DIR=/var/lib/ssl_compat
 
-mkdir -p $REPO_DIR
+# Ensure the repo is tidy
+cleanup () {
+  cd $REPO_DIR
+  /usr/bin/git describe --always --tags --dirty > _revision.info
+  find $REPO_DIR -type d \! -perm 0755 -exec chmod 0755 {} \;
+  find $REPO_DIR -type f \! -perm 0644 -exec chmod 0644 {} \;
+}
 
 # Clone the repository if the local repo is empty or non-existent
 if [ ! -d $REPO_DIR/.git ]
 then
   rm -rf $REPO_DIR
   /usr/bin/git clone $SOURCE_REPO $REPO_DIR
+  cleanup
 fi
 
 # Otherwise, let's just git pull when needed
@@ -23,9 +30,8 @@ REMOTE_REV=$(/usr/bin/git rev-parse origin/master)
 
 # git pull if master and origin/master do not match
 # The local repository should never be ahead of origin/master
-if [ $LOCAL_REV != $REMOTE_REV ]
+if [ "$LOCAL_REV" != "$REMOTE_REV" ]
 then
   /usr/bin/git pull
-  /usr/bin/git describe --always --tags --dirty > _revision.info
+  cleanup
 fi
-

--- a/nubis/puppet/files/update-site.sh
+++ b/nubis/puppet/files/update-site.sh
@@ -2,30 +2,9 @@
 # Copy repository contents to web root
 #
 
-cd /tmp
+REPO_DIR=/var/lib/ssl_compat
 
-# In this environment, git clone fails when run as root
-su - ubuntu -c "/bin/bash /opt/admin-scripts/update-repo.sh"
-
-# Remove unwanted content before publishing
-mkdir /tmp/clean_www
-cp -r /tmp/ssl_compat/* /tmp/clean_www
-
-# Remove files from /tmp/clean_www
-rm -rf /tmp/clean_www/.git*
-rm -rf /tmp/clean_www/.svn*
-rm -rf /tmp/clean_www/CVS
-rm -rf /tmp/clean_www/.bzr*
-
-# Set appropriate permissions for files and directories
-find /tmp/clean_www -type d -exec chmod 755 {} \;
-find /tmp/clean_www -type f -exec chmod 644 {} \;
+/opt/admin-scripts/update-repo.sh
 
 # Write to web root: /var/www/html
-cp -rf /tmp/clean_www/* /var/www/html
-
-# Cleanup to prepare for the next run
-rm -rf /tmp/clean_www
-
-# Make sure unwanted index.html (default Apache page) does not exist:
-rm -rf /var/www/html/index.html
+rsync -a --cvs-exclude --delete $REPO_DIR/ /var/www/html/


### PR DESCRIPTION
Overall:
 - Move git checkout to /var/lib/ssl_compat instead of /tmp
 - Keep /var/lib/ssl_compat clean with proper permissions
 - Use rsync --delete to move from /var/lib/ssl_compat to /var/www/html

Build:
 - Get rid of the submodule, since it's redundant and we don't really bake it in
 - Just call update-site.sh once during build time instead

Fixes #12