### PR TITLE
Support amazon-linux and ubuntu with git pinning

### DIFF
--- a/nubis/puppet/git.pp
+++ b/nubis/puppet/git.pp
@@ -1,7 +1,19 @@
 # Ensure that git is installed
 
+case $::osfamily {
+    'RedHat': {
+        $git_package_version            = '2.7.3-1.46.amzn1'
+    }
+    'Debian', 'Ubuntu': {
+        $git_package_version            = '1:1.9.1-1ubuntu0.3'
+     }
+     default: {
+        fail("Unknown git version for OS ${::osfamily}")
+     }
+}
+
 package {
   'git':
-    ensure => '1:1.9.1-1ubuntu0.3',
+    ensure => $git_package_version,
     name   =>  'git'
 }

--- a/nubis/puppet/git.pp
+++ b/nubis/puppet/git.pp
@@ -1,15 +1,15 @@
 # Ensure that git is installed
 
 case $::osfamily {
-    'RedHat': {
-        $git_package_version            = '2.7.3-1.46.amzn1'
-    }
-    'Debian', 'Ubuntu': {
-        $git_package_version            = '1:1.9.1-1ubuntu0.3'
-     }
-     default: {
-        fail("Unknown git version for OS ${::osfamily}")
-     }
+  'RedHat': {
+    $git_package_version            = '2.7.3-1.46.amzn1'
+  }
+  'Debian', 'Ubuntu': {
+    $git_package_version            = '1:1.9.1-1ubuntu0.3'
+  }
+  default: {
+    fail("Unknown git version for OS ${::osfamily}")
+  }
 }
 
 package {


### PR DESCRIPTION
Since we've been OS agnostic so far, let's try and keep it that way

Improves #16